### PR TITLE
chore: add husky pre-push hook to run build and coverage scripts

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run build && npm run coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "eslint-plugin-testing-library": "^7.1.1",
         "eslint-plugin-vitest": "^0.5.4",
         "globals": "^15.14.0",
+        "husky": "^9.1.7",
         "jsdom": "^25.0.1",
         "prettier": "^3.4.2",
         "react-icons": "^5.4.0",
@@ -5528,6 +5529,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-testing-library": "^7.1.1",
     "eslint-plugin-vitest": "^0.5.4",
     "globals": "^15.14.0",
+    "husky": "^9.1.7",
     "jsdom": "^25.0.1",
     "prettier": "^3.4.2",
     "react-icons": "^5.4.0",


### PR DESCRIPTION
## Changes

- Add husky to run `npm run build` and `npm run coverage` before push

### Testing coverage: 

