### PR TITLE
feat: add reset password functionality to profile route

### DIFF
--- a/src/hooks/useResetPassword.tsx
+++ b/src/hooks/useResetPassword.tsx
@@ -1,6 +1,8 @@
 import { Context } from '@/context';
 import { delay } from '@/helpers';
+import { supabase } from '@/services/supabase';
 import { resetPassword } from '@/services/user';
+import { UserType } from '@/types';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useContext } from 'react';
@@ -49,7 +51,7 @@ const useResetPassword = () => {
     },
   });
 
-  return { mutate, isPending };
+  return { mutate, isPending, sendResetPasswordEmail };
 };
 
 export default useResetPassword;

--- a/src/routes/profile/index.tsx
+++ b/src/routes/profile/index.tsx
@@ -5,6 +5,7 @@ import LoadingLayer from '@/components/LoadingLayer';
 import { CustomSnackbar } from '@/components/Snackbar';
 import { Context } from '@/context';
 import { useAuth } from '@/context/authContext';
+import useResetPassword from '@/hooks/useResetPassword';
 import useUpdateUser from '@/hooks/useUpdateUser';
 import { profileEditSchema } from '@/schemas/profileEditSchema';
 import { SnackbarStateType } from '@/types';
@@ -23,6 +24,7 @@ function RouteComponent() {
   const { mutate: updateUser, isPending: isUpdatingUser } = useUpdateUser();
   const { snackbarState, setSnackbarState } = useContext(Context);
   const navigate = useNavigate();
+  const { sendResetPasswordEmail } = useResetPassword();
 
   const {
     register,
@@ -111,6 +113,13 @@ function RouteComponent() {
 
         <CustomButton disabled={!isValid} type="submit">
           Save
+        </CustomButton>
+        <CustomButton
+          variant="outlined"
+          color="primary"
+          onClick={() => sendResetPasswordEmail(currentSession?.user.email)}
+        >
+          Reset password
         </CustomButton>
       </Box>
       {snackbarState && <CustomSnackbar />}


### PR DESCRIPTION
## Changes

- Add reset password button to `/password`

### Testing coverage: 46.65%

