### PR TITLE
feat/reset-password

### DIFF
--- a/src/hooks/useAuthState.tsx
+++ b/src/hooks/useAuthState.tsx
@@ -27,7 +27,7 @@ export const useAuthState = (): AuthState => {
   const userRef = useRef<User | null>(user);
   const sessionRef = useRef<Session | null>();
 
-  const { data: currentSession, error } = useQuery({
+  const { data: currentSession } = useQuery({
     queryKey: ['fetchSession'],
     queryFn: async () => supabase.auth.getSession(),
   });
@@ -50,14 +50,6 @@ export const useAuthState = (): AuthState => {
             return;
           }
 
-          if (event === 'PASSWORD_RECOVERY') {
-            console.log(
-              'event === "PASSWORD_RECOVERY": ',
-              event === 'PASSWORD_RECOVERY',
-            );
-            return;
-          }
-
           setUser(session?.user ?? null);
           setInitializing(false);
           sessionRef.current = session;
@@ -76,22 +68,6 @@ export const useAuthState = (): AuthState => {
     return () => {
       authListener.subscription.unsubscribe();
     };
-  }, []);
-
-  useEffect(() => {
-    supabase.auth.onAuthStateChange(async (event, session) => {
-      if (event == 'PASSWORD_RECOVERY') {
-        console.log('event == "PASSWORD_RECOVERY":', event, session);
-        const hashParams = new URLSearchParams();
-        hashParams.set('type', 'recovery');
-        sessionRef &&
-          hashParams.set(
-            'access_token',
-            sessionRef.current?.access_token || '',
-          );
-        window.location.href = '/reset-password';
-      }
-    });
   }, []);
 
   return {

--- a/src/hooks/useResetPassword.tsx
+++ b/src/hooks/useResetPassword.tsx
@@ -20,12 +20,7 @@ const useResetPassword = () => {
       return;
     }
 
-    const params = new URLSearchParams();
-    params.set('event', 'PASSWORD_RECOVERY');
-    params.set('type', 'recovery');
-
-    const redirectUrl = `${window.location.origin}/reset-password?${params.toString()}`;
-    console.log(redirectUrl);
+    const redirectUrl = `${window.location.origin}/reset-password`;
 
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
       redirectTo: redirectUrl,
@@ -38,10 +33,6 @@ const useResetPassword = () => {
         : 'A password recovery email has been sent successfully. Please check your inbox for instructions.',
       severity: error ? 'error' : 'success',
     });
-
-    console.log('signing out...');
-
-    await supabase.auth.signOut();
   };
 
   const { mutate, isPending } = useMutation({

--- a/src/routes/profile/index.tsx
+++ b/src/routes/profile/index.tsx
@@ -5,6 +5,7 @@ import LoadingLayer from '@/components/LoadingLayer';
 import { CustomSnackbar } from '@/components/Snackbar';
 import { Context } from '@/context';
 import { useAuth } from '@/context/authContext';
+import useResetPassword from '@/hooks/useResetPassword';
 import useUpdateUser from '@/hooks/useUpdateUser';
 import { profileEditSchema } from '@/schemas/profileEditSchema';
 import { SnackbarStateType } from '@/types';
@@ -23,6 +24,7 @@ function RouteComponent() {
   const { mutate: updateUser, isPending: isUpdatingUser } = useUpdateUser();
   const { snackbarState, setSnackbarState } = useContext(Context);
   const navigate = useNavigate();
+  const { sendResetPasswordEmail } = useResetPassword();
 
   const {
     register,
@@ -35,21 +37,6 @@ function RouteComponent() {
 
   const onSubmit = async (data: any) => {
     updateUser(data);
-  };
-
-  const handleResetPassword = () => {
-    if (!sessionRef) return;
-
-    const hashParams = new URLSearchParams();
-    hashParams.set('event', 'PASSWORD_RECOVERY');
-    hashParams.set('type', 'recovery');
-    hashParams.set('access_token', sessionRef.access_token);
-
-    navigate({
-      to: '/reset-password',
-      hash: hashParams.toString(),
-      viewTransition: true,
-    });
   };
 
   useEffect(() => {
@@ -130,7 +117,7 @@ function RouteComponent() {
         <CustomButton
           variant="outlined"
           color="primary"
-          onClick={handleResetPassword}
+          onClick={() => sendResetPasswordEmail(sessionRef?.user.email)}
         >
           Reset password
         </CustomButton>

--- a/src/routes/reset-password/index.tsx
+++ b/src/routes/reset-password/index.tsx
@@ -27,7 +27,7 @@ function RouteComponent() {
 
   useEffect(() => {
     supabase.auth.onAuthStateChange(async (event, session) => {
-      if (event !== 'PASSWORD_RECOVERY' && !session) {
+      if (event !== 'PASSWORD_RECOVERY') {
         setShouldNavigate(true);
       }
     });

--- a/src/routes/reset-password/index.tsx
+++ b/src/routes/reset-password/index.tsx
@@ -1,6 +1,6 @@
 import CustomButton from '@/components/Button';
 import InputPassword from '@/components/InputPassword';
-import LoadingLayer from '@/components/LoadingLayer';
+import LoadingLayr from '@/components/LoadingLayer';
 import { CustomSnackbar } from '@/components/Snackbar';
 import { Context } from '@/context';
 import { useAuth } from '@/context/authContext';
@@ -18,21 +18,17 @@ export const Route = createFileRoute('/reset-password/')({
 });
 
 function RouteComponent() {
-  const {
-    mutate: resetPassword,
-    isPending: isPendingResetPassword,
-    sendResetPasswordEmail,
-  } = useResetPassword();
+  const { mutate: resetPassword, isPending: isPendingResetPassword } =
+    useResetPassword();
   const { sessionRef } = useAuth();
-  const { snackbarState, setSnackbarState } = useContext(Context);
+  const { snackbarState } = useContext(Context);
   const navigate = useNavigate();
   const [shouldNavigate, setShouldNavigate] = useState(false);
 
   useEffect(() => {
     supabase.auth.onAuthStateChange(async (event, session) => {
-      if (event !== 'PASSWORD_RECOVERY') {
-        if (!session) setShouldNavigate(true);
-        return;
+      if (event !== 'PASSWORD_RECOVERY' && !session) {
+        setShouldNavigate(true);
       }
     });
   }, []);
@@ -68,7 +64,6 @@ function RouteComponent() {
   }) => {
     resetPassword({
       newPassword: data.password,
-      currentPassword: data.currentPassword,
     });
   };
 


### PR DESCRIPTION
## Changes

- Refactor password resetting flow - reset password buttons will send an email with a link to `/reset-password`, which will direct user to `/profile` or `/login` if `event` is not `'PASSWORD_RECOVERY`'

### Testing coverage: 

